### PR TITLE
FIX: Update ft_updates when accounts is non empty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "compact-indexer"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compact-indexer"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Eugene The Dream"]
 rust-version = "1.79.0"
 edition = "2021"

--- a/src/bin/ft_red.rs
+++ b/src/bin/ft_red.rs
@@ -178,7 +178,7 @@ async fn listen_blocks(
                 .arg(block_height)
                 .ignore();
 
-            if !ft_pairs.is_empty() {
+            if !ft_pairs.is_empty() || !accounts.is_empty() {
                 pipe.cmd("RPUSH")
                     .arg("ft_updates")
                     .arg(json!({


### PR DESCRIPTION
Fixes an issue when ft_updates were not filled if ft_pairs were empty, but accounts were not empty
